### PR TITLE
fix: destroy `_resizeObject` to avoid potential memory leak

### DIFF
--- a/src/components/ResizeObserver.vue
+++ b/src/components/ResizeObserver.vue
@@ -36,7 +36,9 @@ export default {
 				if (!isIE && this._resizeObject.contentDocument) {
 					this._resizeObject.contentDocument.defaultView.removeEventListener('resize', this.compareAndNotify)
 				}
-				delete this._resizeObject.onload
+				this.$el.removeChild(this._resizeObject)
+				this._resizeObject.onload = null
+				this._resizeObject = null
 			}
 		},
 	},


### PR DESCRIPTION
I'm facing some severe memory leak issues recently. After some digging, I found that RecycleScroller haven't been destroyed under certain circumastances.

https://github.com/Akryum/vue-resize/blob/2f6c0904fb0da5f4185e362383d8bfe9b66455d8/src/components/ResizeObserver.vue#L39

the code above can't actually remove the event listener, instead, we should assign the value to `null` :

<image width="173" src="https://user-images.githubusercontent.com/13914967/79066669-52b5e580-7cec-11ea-86f5-5a4c9dd22764.png" >

And the reference to `_resizeObject` should also be removed, to allow GC of the entrie DOM tree, see: https://developers.google.com/web/tools/chrome-devtools/memory-problems/heap-snapshots#uncover_dom_leaks
